### PR TITLE
Sticky tiles (body-to-tile snapping)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   tile-specific callbacks and layer-level tile callbacks
 - Tile slope type name retrieval
 - Arcade body properties that configure the body's interaction with tiles
+- Initial sticky slopes functionality
 
 ## v0.1.0-alpha3 - 11th May 2016
 - Further improved heuristics

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ learn than to build something yourself?
   - [x] Full support for collision callbacks
     - [x] `physics.arcade.collide` callbacks
     - [x] Tile callbacks
-  - [ ] Sticky slopes
+  - [x] Sticky slopes
   - [x] Friction
   - [x] `body.slope` properties for friction, sticky slopes, preferred
     separation axis and last overlap response

--- a/src/ArcadeSlopes.js
+++ b/src/ArcadeSlopes.js
@@ -180,7 +180,10 @@ Phaser.Plugin.ArcadeSlopes.prototype.enableBody = function (body) {
 		sat: {
 			response: null,
 		},
+		snapUp: 0,
 		snapDown: 0,
+		snapLeft: 0,
+		snapRight: 0
 	};
 };
 

--- a/src/ArcadeSlopes.js
+++ b/src/ArcadeSlopes.js
@@ -179,7 +179,8 @@ Phaser.Plugin.ArcadeSlopes.prototype.enableBody = function (body) {
 		preferY: false,
 		sat: {
 			response: null,
-		}
+		},
+		snapDown: 0,
 	};
 };
 

--- a/src/ArcadeSlopes/Overrides.js
+++ b/src/ArcadeSlopes/Overrides.js
@@ -58,13 +58,13 @@ Phaser.Plugin.ArcadeSlopes.Overrides.collideSpriteVsTile = function (i, sprite, 
  * Collide a sprite against a set of tiles.
  *
  * @method Phaser.Plugin.ArcadeSlopes.Overrides#collideSpriteVsTiles
- * @param {Phaser.Sprite}       sprite           - The sprite to check.
- * @param {Phaser.Tile[]}       tiles            - The tiles to check.
- * @param {function}            collideCallback  - An optional collision callback.
- * @param {function}            processCallback  - An optional overlap processing callback.
- * @param {object}              callbackContext  - The context in which to run the callbacks.
- * @param {boolean}             overlapOnly      - Whether to only check for an overlap.
- * @return {boolean}                             - Whether a collision occurred.
+ * @param  {Phaser.Sprite}       sprite           - The sprite to check.
+ * @param  {Phaser.Tile[]}       tiles            - The tiles to check.
+ * @param  {function}            collideCallback  - An optional collision callback.
+ * @param  {function}            processCallback  - An optional overlap processing callback.
+ * @param  {object}              callbackContext  - The context in which to run the callbacks.
+ * @param  {boolean}             overlapOnly      - Whether to only check for an overlap.
+ * @return {boolean}                              - Whether a collision occurred.
  */
 Phaser.Plugin.ArcadeSlopes.Overrides.collideSpriteVsTiles = function (sprite, tiles, collideCallback, processCallback, callbackContext, overlapOnly) {
 	var collided = false;
@@ -74,14 +74,12 @@ Phaser.Plugin.ArcadeSlopes.Overrides.collideSpriteVsTiles = function (sprite, ti
 	}
 	
 	for (var i = 0; i < tiles.length; i++) {
-		var tile = tiles[i];
-		
 		if (processCallback) {
 			if (processCallback.call(callbackContext, sprite, tiles[i])) {
 				collided = this.collideSpriteVsTile(i, sprite, tiles[i], collideCallback, processCallback, callbackContext, overlapOnly) || collided;
 			}
 		} else {
-			collided = this.collideSpriteVsTile(i, sprite, tile, collideCallback, processCallback, callbackContext, overlapOnly) || collided;
+			collided = this.collideSpriteVsTile(i, sprite, tiles[i], collideCallback, processCallback, callbackContext, overlapOnly) || collided;
 		}
 	}
 	

--- a/src/ArcadeSlopes/SatSolver.js
+++ b/src/ArcadeSlopes/SatSolver.js
@@ -162,11 +162,12 @@ Phaser.Plugin.ArcadeSlopes.SatSolver.prototype.shouldPreferY = function (body, r
  * Determine whether two polygons intersect on a given axis.
  *
  * @static
- * @param  {SAT.Polygon}  a        The first polygon.
- * @param  {SAT.Polygon}  b        The second polygon.
- * @param  {SAT.Vector}   axis     The axis to test.
- * @param  {SAT.Response} response The response to populate.
- * @return {boolean}               Whether a separating axis was found.
+ * @method Phaser.Plugin.ArcadeSlopes.SatSolver#isSeparatingAxis
+ * @param  {SAT.Polygon}  a        - The first polygon.
+ * @param  {SAT.Polygon}  b        - The second polygon.
+ * @param  {SAT.Vector}   axis     - The axis to test.
+ * @param  {SAT.Response} response - The response to populate.
+ * @return {boolean}               - Whether a separating axis was found.
  */
 Phaser.Plugin.ArcadeSlopes.SatSolver.isSeparatingAxis = function (a, b, axis, response) {
 	var result = SAT.isSeparatingAxis(a.pos, b.pos, a.points, b.points, axis, response || null);
@@ -277,7 +278,7 @@ Phaser.Plugin.ArcadeSlopes.SatSolver.prototype.updateFlags = function (body, res
 /**
  * Attempt to snap the body to a given set of tiles based on its slopes options.
  *
- * @method Phaser.Plugin.ArcadeSlopes.SatSolver#attemptSnapping
+ * @method Phaser.Plugin.ArcadeSlopes.SatSolver#snap
  * @param  {Phaser.Physics.Arcade.Body} body  - The physics body.
  * @param  {Phaser.Tile[]}              tiles - The tiles.
  * @return {boolean}                          - Whether the body was snapped to any tiles.


### PR DESCRIPTION
An attempt at configurable snapping to tiles for physics bodies.

Works by moving the body in each direction by a configured amount if it didn't collide with anything, re-testing for collisions with the tiles and rolling with it if successful, but returning to its original position otherwise.

Controlled using `sprite.body.slopes.snapDown`, `snapUp`, `snapLeft` and `snapRight`, which can be set to the distance in pixels to test in each direction.

Not as smooth and glitch-free as I'd like, but it's not a bad start I suppose. It works really well for descending slopes, not so well when ascending (depends on the configuration I suppose).

Small amounts of refactoring in here too.
