### PR TITLE
Typedef Fixes

### DIFF
--- a/typescript/phaser-arcade-slopes.d.ts
+++ b/typescript/phaser-arcade-slopes.d.ts
@@ -99,7 +99,7 @@ declare module Phaser {
 				debug(position:Phaser.Point, response:SAT.Response):void;
 			}
 
-			class SatSolverOptions {
+			interface SatSolverOptions {
 				preferY:boolean;
 				stick:Phaser.Point;
 				restrain:boolean;
@@ -187,7 +187,7 @@ declare module Phaser {
 				createQuarterTopRightHigh(type:number, tile:Phaser.Tile):Phaser.Plugin.ArcadeSlopes.TileSlope;
 			}
 
-			class BodySlopes {
+			interface BodySlopes {
 				friction:Phaser.Point;
 				preferY:boolean;
 				pullUp:number;
@@ -203,7 +203,7 @@ declare module Phaser {
 				velocity:SAT.Vector;
 			}
 
-			class BodySlopesSat {
+			interface BodySlopesSat {
 				response:SAT.Response;
 			}
 		}

--- a/typescript/phaser-arcade-slopes.d.ts
+++ b/typescript/phaser-arcade-slopes.d.ts
@@ -3,9 +3,11 @@ declare module Phaser {
 		slopes:Phaser.Plugin.ArcadeSlopes;
 	}
 
-	module Physics.Arcade {
-		interface Body {
-			slopes:Phaser.Plugin.ArcadeSlopes;
+	module Physics {
+		module Arcade {
+			interface Body {
+				slopes:Phaser.Plugin.ArcadeSlopes.BodySlopes;
+			}
 		}
 	}
 
@@ -13,6 +15,11 @@ declare module Phaser {
 		class ArcadeSlopes extends Phaser.Plugin {
 			static SAT:string;
 			static METROID:string;
+
+			defaultSolver:string;
+			factory:Phaser.Plugin.ArcadeSlopes.TileSlopeFactory;
+			solvers:Object;
+
 			enable(obj:Phaser.Sprite | Phaser.Group):void;
 			enableBody(body:Phaser.Physics.Arcade.Body):void;
 			convertTilemap(map:Phaser.Tilemap, layer:number | string | Phaser.TilemapLayer, slopeMap:Object):Phaser.Tilemap;
@@ -21,7 +28,6 @@ declare module Phaser {
 		}
 
 		module ArcadeSlopes {
-
 
 			class Facade {
 				factory:Phaser.Plugin.ArcadeSlopes.TileSlopeFactory;
@@ -170,6 +176,26 @@ declare module Phaser {
 				createQuarterTopLeftHigh(type:number, tile:Phaser.Tile):Phaser.Plugin.ArcadeSlopes.TileSlope;
 				createQuarterTopRightLow(type:number, tile:Phaser.Tile):Phaser.Plugin.ArcadeSlopes.TileSlope;
 				createQuarterTopRightHigh(type:number, tile:Phaser.Tile):Phaser.Plugin.ArcadeSlopes.TileSlope;
+			}
+
+			class BodySlopes {
+				friction:Phaser.Point;
+				preferY:boolean;
+				pullUp:number;
+				pullDown:number;
+				pullLeft:number;
+				pullRight:number;
+				sat:Phaser.Plugin.ArcadeSlopes.BodySlopesSat;
+				skipFriction:boolean;
+				snapUp:number;
+				snapDown:number;
+				snapLeft:number;
+				snapRight:number;
+				velocity:SAT.Vector;
+			}
+
+			class BodySlopesSat {
+				respone:SAT.Response;
 			}
 		}
 	}

--- a/typescript/phaser-arcade-slopes.d.ts
+++ b/typescript/phaser-arcade-slopes.d.ts
@@ -3,11 +3,9 @@ declare module Phaser {
 		slopes:Phaser.Plugin.ArcadeSlopes;
 	}
 
-	module Physics {
-		module Arcade {
-			interface Body {
-				slopes:Phaser.Plugin.ArcadeSlopes.BodySlopes;
-			}
+	module Physics.Arcade {
+		interface Body {
+			slopes:Phaser.Plugin.ArcadeSlopes.BodySlopes;
 		}
 	}
 
@@ -15,11 +13,6 @@ declare module Phaser {
 		class ArcadeSlopes extends Phaser.Plugin {
 			static SAT:string;
 			static METROID:string;
-
-			defaultSolver:string;
-			factory:Phaser.Plugin.ArcadeSlopes.TileSlopeFactory;
-			solvers:Object;
-
 			enable(obj:Phaser.Sprite | Phaser.Group):void;
 			enableBody(body:Phaser.Physics.Arcade.Body):void;
 			convertTilemap(map:Phaser.Tilemap, layer:number | string | Phaser.TilemapLayer, slopeMap:Object):Phaser.Tilemap;
@@ -176,26 +169,6 @@ declare module Phaser {
 				createQuarterTopLeftHigh(type:number, tile:Phaser.Tile):Phaser.Plugin.ArcadeSlopes.TileSlope;
 				createQuarterTopRightLow(type:number, tile:Phaser.Tile):Phaser.Plugin.ArcadeSlopes.TileSlope;
 				createQuarterTopRightHigh(type:number, tile:Phaser.Tile):Phaser.Plugin.ArcadeSlopes.TileSlope;
-			}
-
-			class BodySlopes {
-				friction:Phaser.Point;
-				preferY:boolean;
-				pullUp:number;
-				pullDown:number;
-				pullLeft:number;
-				pullRight:number;
-				sat:Phaser.Plugin.ArcadeSlopes.BodySlopesSat;
-				skipFriction:boolean;
-				snapUp:number;
-				snapDown:number;
-				snapLeft:number;
-				snapRight:number;
-				velocity:SAT.Vector;
-			}
-
-			class BodySlopesSat {
-				respone:SAT.Response;
 			}
 		}
 	}

--- a/typescript/phaser-arcade-slopes.d.ts
+++ b/typescript/phaser-arcade-slopes.d.ts
@@ -170,6 +170,26 @@ declare module Phaser {
 				createQuarterTopRightLow(type:number, tile:Phaser.Tile):Phaser.Plugin.ArcadeSlopes.TileSlope;
 				createQuarterTopRightHigh(type:number, tile:Phaser.Tile):Phaser.Plugin.ArcadeSlopes.TileSlope;
 			}
+
+			class BodySlopes {
+				friction:Phaser.Point;
+				preferY:boolean;
+				pullUp:number;
+				pullDown:number;
+				pullLeft:number;
+				pullRight:number;
+				sat:Phaser.Plugin.ArcadeSlopes.BodySlopesSat;
+				skipFriction:boolean;
+				snapUp:number;
+				snapDown:number;
+				snapLeft:number;
+				snapRight:number;
+				velocity:SAT.Vector;
+			}
+
+			class BodySlopesSat {
+				response:SAT.Response;
+			}
 		}
 	}
 }

--- a/typescript/phaser-arcade-slopes.d.ts
+++ b/typescript/phaser-arcade-slopes.d.ts
@@ -11,9 +11,6 @@ declare module Phaser {
 
 	module Plugin {
 		class ArcadeSlopes extends Phaser.Plugin {
-			static SAT:string;
-			static METROID:string;
-
 			constructor(game:Phaser.Game, parent:any, defaultSolver:number);
 
 			defaultSolver:string;
@@ -25,6 +22,9 @@ declare module Phaser {
 			convertTilemap(map:Phaser.Tilemap, layer:number | string | Phaser.TilemapLayer, slopeMap:Object):Phaser.Tilemap;
 			convertTilemapLayer(layer:Phaser.TilemapLayer, slopeMap:Object):Phaser.TilemapLayer;
 			collide(i:number, body:Phaser.Physics.Arcade.Body, tile:Phaser.Tile, overlapOnly:boolean):boolean;
+
+			static SAT:string;
+			static METROID:string;
 		}
 
 		module ArcadeSlopes {
@@ -219,6 +219,7 @@ declare module SAT {
 		overlap:number;
 		overlapV:SAT.Vector;
 		overlapN:SAT.Vector;
+
 		clear();
 
 	}
@@ -248,6 +249,7 @@ declare module SAT {
 	interface Circle {
 		pos:SAT.Vector;
 		r:number;
+
 		getAABB():SAT.Box;
 	}
 
@@ -275,9 +277,7 @@ declare class SAT {
 	static T_ARRAYS:number[];
 	static T_RESPONSE:SAT.Response[];
 	static T_POLYGONS:SAT.Polygon[];
-
 	static UNIT_SQUARE:SAT.Polygon;
-
 	static LEFT_VORONOI_REGION:number;
 	static MIDDLE_VORONOI_REGION:number;
 	static RIGHT_VORONOI_REGION:number;

--- a/typescript/phaser-arcade-slopes.d.ts
+++ b/typescript/phaser-arcade-slopes.d.ts
@@ -13,6 +13,11 @@ declare module Phaser {
 		class ArcadeSlopes extends Phaser.Plugin {
 			static SAT:string;
 			static METROID:string;
+
+			defaultSolver:string;
+			solvers:Object;
+			facade:Phaser.Plugin.ArcadeSlopes.Facade;
+
 			enable(obj:Phaser.Sprite | Phaser.Group):void;
 			enableBody(body:Phaser.Physics.Arcade.Body):void;
 			convertTilemap(map:Phaser.Tilemap, layer:number | string | Phaser.TilemapLayer, slopeMap:Object):Phaser.Tilemap;

--- a/typescript/phaser-arcade-slopes.d.ts
+++ b/typescript/phaser-arcade-slopes.d.ts
@@ -14,6 +14,8 @@ declare module Phaser {
 			static SAT:string;
 			static METROID:string;
 
+			constructor(game:Phaser.Game, parent:any, defaultSolver:number);
+
 			defaultSolver:string;
 			solvers:Object;
 			facade:Phaser.Plugin.ArcadeSlopes.Facade;
@@ -28,9 +30,12 @@ declare module Phaser {
 		module ArcadeSlopes {
 
 			class Facade {
+				constructor(factory:Phaser.Plugin.ArcadeSlopes.TileSlopeFactory, solvers:Object, defaultSolver:number);
+
 				factory:Phaser.Plugin.ArcadeSlopes.TileSlopeFactory;
 				solvers:Object;
 				defaultSover:number;
+
 				enable(obj:Phaser.Sprite | Phaser.Group):void;
 				enableBody(body:Phaser.Physics.Arcade.Body):void;
 				convertTilemap(map:Phaser.Tilemap, layer:number | string | Phaser.TilemapLayer, slopeMap:Object):Phaser.Tilemap;
@@ -58,6 +63,7 @@ declare module Phaser {
 				topRightVerticies:string[];
 				bottomLeftVerticies:string[];
 				bottomRightVerticies:string[];
+
 				restrain(solver:Phaser.Plugin.ArcadeSlopes.SatSolver, body:Phaser.Physics.Arcade.Body, tile:Phaser.Tile, response:SAT.Response):boolean;
 				resolveOverlaps(direction:string):Object;
 				prepareRestraints(restraints:Object):Object;
@@ -67,8 +73,11 @@ declare module Phaser {
 			}
 
 			class SatSolver {
+				constructor(options:Phaser.Plugin.ArcadeSlopes.SatSolverOptions);
+
 				options:Phaser.Plugin.ArcadeSlopes.SatSolverOptions;
 				restrainers:Phaser.Plugin.ArcadeSlopes.SatRestainer;
+
 				prepareResponse(response:SAT.Response):SAT.Response;
 				putOnSlopeX(body:Phaser.Physics.Arcade.Body, tile:Phaser.Tile):void;
 				putOnSlopeY(body:Phaser.Physics.Arcade.Body, tile:Phaser.Tile):void;
@@ -97,6 +106,7 @@ declare module Phaser {
 			}
 
 			class TileSlope {
+				constructor(type:number, tile:Phaser.Tile, polygon:SAT.Polygon, line:Phaser.Line, edges:Object, axis:SAT.Vector);
 				type:number;
 				tile:Phaser.Tile;
 				polygon:SAT.Polygon;
@@ -108,6 +118,7 @@ declare module Phaser {
 				slope:number;
 				typeName:string;
 				typeNames:Object;
+
 				resolveType(type:string | number):number;
 				resolveTypeName(type:number):number;
 


### PR DESCRIPTION
Fixes for the typedefs.

There are some interfaces in the definition that are there solely for type validation.  Otherwise it would be a bit of a pain in Typescript to create these objects.  (BodySlopes, BodySlopesSat and SatSolverOptions).
